### PR TITLE
Implemented support for speed over accuracy

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/ocrit.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ocrit.xcscheme
@@ -94,7 +94,7 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "/Users/insidegui/Developer/_projects/ocrit/Tests/ocritTests/Resources/test-multi-en-ko.png"
+            argument = "/Users/insidegui/Developer/_projects/ocrit/Tests/ocritTests/Resources/test-en.png"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
@@ -107,11 +107,11 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-l"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "ko-KR"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-l"
@@ -119,6 +119,10 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "en-US"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--fast"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Sources/ocrit/Implementation/Base/CGImageOCR.swift
+++ b/Sources/ocrit/Implementation/Base/CGImageOCR.swift
@@ -14,9 +14,9 @@ final class CGImageOCR {
     private var request: VNRecognizeTextRequest?
     private var handler: VNImageRequestHandler?
 
-    func run() async throws -> String {
+    func run(fast: Bool) async throws -> String {
         return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) -> Void in
-            performRequest(with: image) { request, error in
+            performRequest(with: image, level: fast ? .fast : .accurate) { request, error in
                 if let error = error {
                     continuation.resume(throwing: error)
                 } else {
@@ -37,11 +37,11 @@ final class CGImageOCR {
         }
     }
 
-    func performRequest(with image: CGImage, completion: @escaping VNRequestCompletionHandler) {
+    func performRequest(with image: CGImage, level: VNRequestTextRecognitionLevel, completion: @escaping VNRequestCompletionHandler) {
         let newHandler = VNImageRequestHandler(cgImage: image)
 
         let newRequest = VNRecognizeTextRequest(completionHandler: completion)
-        newRequest.recognitionLevel = .accurate
+        newRequest.recognitionLevel = level
 
         do {
             if let customLanguages = try resolveLanguages(for: newRequest) {

--- a/Sources/ocrit/Implementation/Base/OCROperation.swift
+++ b/Sources/ocrit/Implementation/Base/OCROperation.swift
@@ -7,5 +7,5 @@ struct OCRResult {
 
 protocol OCROperation {
     init(fileURL: URL, customLanguages: [String])
-    func run() throws -> AsyncThrowingStream<OCRResult, Error>
+    func run(fast: Bool) throws -> AsyncThrowingStream<OCRResult, Error>
 }

--- a/Sources/ocrit/Implementation/ImageOCROperation.swift
+++ b/Sources/ocrit/Implementation/ImageOCROperation.swift
@@ -11,7 +11,7 @@ final class ImageOCROperation: OCROperation {
         self.customLanguages = customLanguages
     }
 
-    func run() throws -> AsyncThrowingStream<OCRResult, Error> {
+    func run(fast: Bool) throws -> AsyncThrowingStream<OCRResult, Error> {
         guard let image = NSImage(contentsOf: imageURL) else {
             throw Failure("Couldn't read image at \(imageURL.path)")
         }
@@ -27,7 +27,7 @@ final class ImageOCROperation: OCROperation {
         return AsyncThrowingStream { continuation in
             Task {
                 do {
-                    let text = try await ocr.run()
+                    let text = try await ocr.run(fast: fast)
 
                     let result = OCRResult(text: text, suggestedFilename: filename)
 

--- a/Sources/ocrit/Implementation/PDFOCROperation.swift
+++ b/Sources/ocrit/Implementation/PDFOCROperation.swift
@@ -11,7 +11,7 @@ final class PDFOCROperation: OCROperation {
         self.customLanguages = customLanguages
     }
 
-    func run() throws -> AsyncThrowingStream<OCRResult, Error> {
+    func run(fast: Bool) throws -> AsyncThrowingStream<OCRResult, Error> {
         let basename = documentURL.deletingPathExtension().lastPathComponent
 
         guard let document = CGPDFDocument(documentURL as CFURL) else {
@@ -30,7 +30,7 @@ final class PDFOCROperation: OCROperation {
 
                         let ocr = CGImageOCR(image: cgImage, customLanguages: customLanguages)
 
-                        let text = try await ocr.run()
+                        let text = try await ocr.run(fast: fast)
 
                         let result = OCRResult(text: text, suggestedFilename: basename + "-\(page)")
 

--- a/Sources/ocrit/OCRIT.swift
+++ b/Sources/ocrit/OCRIT.swift
@@ -21,6 +21,9 @@ struct ocrit: AsyncParsableCommand {
     @Option(name: .shortAndLong, help: "Language code to use for the recognition, can be repeated to select multiple languages")
     var language: [String] = []
 
+    @Flag(name: .shortAndLong, help: "Uses an OCR algorithm that prioritizes speed over accuracy")
+    var fast = false
+
     private var shouldOutputToStdout: Bool { output == "-" }
 
     func run() async throws {
@@ -77,7 +80,7 @@ struct ocrit: AsyncParsableCommand {
             let operation = operationType.init(fileURL: url, customLanguages: language)
 
             do {
-                for try await result in try operation.run() {
+                for try await result in try operation.run(fast: fast) {
                     try writeResult(result, for: url, outputDirectoryURL: outputDirectoryURL)
                 }
             } catch {

--- a/Tests/ocritTests/ocritTests.swift
+++ b/Tests/ocritTests/ocritTests.swift
@@ -76,6 +76,16 @@ final class OCRITTests: XCTestCase {
         )
     }
 
+    func testSpeedOverAccuracy() throws {
+        let input = fixturePath(named: "test-en.png")
+
+        try AssertExecuteCommand(
+            command: "ocrit \(input) --fast",
+            expected: .stdout(.equal("test-en.png:\nSome text in English")),
+            exitCode: .success
+        )
+    }
+
     func testMultipleImagesOutputToDirectory() throws {
         let outputURL = try getScratchDirectory()
         


### PR DESCRIPTION
Adds a new `--fast` flag that can be used to enable `VNRequestTextRecognitionLevel.fast` instead of `.accurate`.