### PR TITLE
Use PathKit, add Output type, and validate input

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,24 @@
 {
   "pins" : [
     {
+      "identity" : "pathkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/PathKit",
+      "state" : {
+        "revision" : "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+        "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "spectre",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/Spectre.git",
+      "state" : {
+        "revision" : "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+        "version" : "0.10.1"
+      }
+    },
+    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",

--- a/Package.swift
+++ b/Package.swift
@@ -6,13 +6,15 @@ let package = Package(
     name: "ocrit",
     platforms: [.macOS(.v12)],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.1.0")
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.1.0"),
+        .package(url: "https://github.com/kylef/PathKit", from: "1.0.1")
     ],
     targets: [
         .executableTarget(
             name: "ocrit",
             dependencies: [
-                .product(name: "ArgumentParser", package: "swift-argument-parser")
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "PathKit", package: "PathKit")
             ]),
         .testTarget(
             name: "ocritTests",

--- a/Sources/ocrit/Implementation/Base/CGImageOCR.swift
+++ b/Sources/ocrit/Implementation/Base/CGImageOCR.swift
@@ -65,27 +65,4 @@ final class CGImageOCR {
     private func resolveLanguages(for request: VNRecognizeTextRequest) throws -> [String]? {
         try request.validateLanguages(with: customLanguages)
     }
-
-}
-
-extension VNRecognizeTextRequest {
-    @discardableResult
-    static func validateLanguages(with customLanguages: [String]) throws -> [String]? {
-        let dummy = VNRecognizeTextRequest()
-        return try dummy.validateLanguages(with: customLanguages)
-    }
-
-    fileprivate func validateLanguages(with customLanguages: [String]) throws -> [String]? {
-        guard !customLanguages.isEmpty else { return nil }
-
-        let supportedLanguages = try supportedRecognitionLanguages()
-
-        for customLanguage in customLanguages {
-            guard supportedLanguages.contains(customLanguage) else {
-                throw Failure("Unsupported language \"\(customLanguage)\". Supported languages are: \(supportedLanguages.joined(separator: ", "))")
-            }
-        }
-
-        return customLanguages
-    }
 }

--- a/Sources/ocrit/Implementation/Base/VNRecognizeTextRequest+Validation.swift
+++ b/Sources/ocrit/Implementation/Base/VNRecognizeTextRequest+Validation.swift
@@ -1,0 +1,24 @@
+import ArgumentParser
+import Vision
+
+extension VNRecognizeTextRequest {
+    @discardableResult
+    static func validateLanguages(with customLanguages: [String]) throws -> [String]? {
+        let dummy = VNRecognizeTextRequest()
+        return try dummy.validateLanguages(with: customLanguages)
+    }
+
+    func validateLanguages(with customLanguages: [String]) throws -> [String]? {
+        guard !customLanguages.isEmpty else { return nil }
+
+        let supportedLanguages = try supportedRecognitionLanguages()
+
+        for customLanguage in customLanguages {
+            guard supportedLanguages.contains(customLanguage) else {
+                throw ValidationError("Unsupported language \"\(customLanguage)\". Supported languages are: \(supportedLanguages.joined(separator: ", "))")
+            }
+        }
+
+        return customLanguages
+    }
+}

--- a/Sources/ocrit/Output.swift
+++ b/Sources/ocrit/Output.swift
@@ -1,0 +1,35 @@
+import ArgumentParser
+import Foundation
+import PathKit
+
+enum Output {
+    case stdOutput
+    case path(Path)
+}
+
+extension Output: ExpressibleByArgument {
+    init?(argument: String) {
+        if argument == "-" {
+            self = .stdOutput
+        }
+
+        let path = Path(argument).absolute()
+        self = .path(path)
+    }
+}
+
+extension Output {
+    var isStdOutput: Bool {
+        switch self {
+        case .stdOutput: true
+        default: false
+        }
+    }
+
+    var path: Path? {
+        switch self {
+        case let .path(path): path
+        default: nil
+        }
+    }
+}

--- a/Sources/ocrit/Path+ArgumentParser.swift
+++ b/Sources/ocrit/Path+ArgumentParser.swift
@@ -1,0 +1,8 @@
+import ArgumentParser
+import PathKit
+
+extension Path: @retroactive ExpressibleByArgument {
+    public init?(argument: String) {
+        self = Path(argument).absolute()
+    }
+}

--- a/Tests/ocritTests/ocritTests.swift
+++ b/Tests/ocritTests/ocritTests.swift
@@ -72,7 +72,7 @@ final class OCRITTests: XCTestCase {
         try AssertExecuteCommand(
             command: "ocrit \(input) --language someinvalidlanguage",
             expected: .stderr(.contain("Unsupported language")),
-            exitCode: .failure
+            exitCode: .validationFailure
         )
     }
 


### PR DESCRIPTION
This PR includes the changes we've done together for the video:

* Add PathKit as a dependency, for type-safe path handling
* Add the `Output`, which contains two cases: `stdOutput`, and `path(Path)`
* Validate user input in the `validate()` function, instead of doing it in `run()`